### PR TITLE
Split test annotations by job, add a preamble for clarity

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -44,9 +44,13 @@ type BuildkitePlugin struct {
 	// the build for more clarity.
 	failedActions []*failedAction
 
-	// BuildkiteAnalyticsTokenName is the name of the env var we should be reading
+	// buildkiteAnalyticsTokenName is the name of the env var we should be reading
 	// the token from or defaults to read it from "$BUILDKITE_ANALYTICS_TOKEN".
 	buildkiteAnalyticsToken string
+
+	// isPreamblePosted tells us if we have posted or not the preamble, as we don't have
+	// a final or first hook to run things before or after the completion of the entire build.
+	isPreamblePosted bool
 }
 
 type pluginProperties struct {
@@ -249,7 +253,26 @@ func (p *BuildkitePlugin) hook(_ bool, pr ioutils.PromptRunner) error {
 	return nil
 }
 
+// testPreamble is the text posted before anything else in the error annotation at the top of the build
+// if there is a failed test detected the build. The final two line breaks are important, because they
+// allow the formatting to be readable when we're posting the list of failed test targets.
+var testPreamble = `:bulb: You can run the following failed test targets with 'bazel test [target]' locally on your
+machine to reproduce the issues and iterate faster than having to wait for the CI again.
+
+If a particular test target is too slow to build, you can also use 'sg ci bazel test [target]' to have the CI run that 
+only particular target.
+
+
+`
+
 func (p *BuildkitePlugin) annotateFailedTests(ctx context.Context) error {
+	if len(p.testResultInfos) > 0 && !p.isPreamblePosted {
+		p.isPreamblePosted = true
+		if err := p.agent.Annotate(ctx, "error", "failed_test", []byte(testPreamble)); err != nil {
+			return err
+		}
+	}
+
 	for _, result := range p.testResultInfos {
 		var testLogPath string
 


### PR DESCRIPTION
Follow-up to https://github.com/sourcegraph/devx-support/issues/193

Previously, all test failures were sent to the same "annotation group", which has the incovenient of showing duplicates in not so logic way. 

Now, there is one annotation per job, and a link to jump to the job in question. 

Please ignore the dumb mistake in the screenshot, I don't want to take another 10m to wait the build to be able to test it, given I'm going to build it anyway once it's merged. I'll also turn the h2 into a h4, that's too big. 

<img width="1181" alt="CleanShot 2023-08-22 at 16 43 38@2x" src="https://github.com/sourcegraph/aspect-cli-plugin-buildkite/assets/10151/bb75ddd3-2821-4955-8f35-1989ed5919cd">

